### PR TITLE
fix gcc warning

### DIFF
--- a/libhidx_server_daemon/src/main.cc
+++ b/libhidx_server_daemon/src/main.cc
@@ -38,11 +38,11 @@ int main(int argc, char* argv[]){
 
     try {
         parser.ParseCLI(argc, argv);
-    } catch (args::ParseError e) {
+    } catch (const args::ParseError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << parser;
         return 1;
-    } catch (args::ValidationError e) {
+    } catch (const args::ValidationError& e) {
         std::cerr << e.what() << std::endl;
         std::cerr << parser;
         return 1;


### PR DESCRIPTION
It's good idea to catch exception as reference.